### PR TITLE
Fix creation of Redis user group.

### DIFF
--- a/roles/database/redis/tasks/main.yml
+++ b/roles/database/redis/tasks/main.yml
@@ -15,7 +15,7 @@
 
 ## Configure user
 - name: Redis | Setup group
-  user: name={{ redis_group }}
+  group: name={{ redis_group }}
 - name: Redis | Setup user
   user: name={{ redis_user }} group={{ redis_group }} home="/var/lib/redis" shell="/bin/false" comment="Redis Server"
 


### PR DESCRIPTION
Use the `group` module for setting up the Redis group, instead of the `user` module.
