### PR TITLE
Replace legacy "action:" task syntax with shorthand equivalent

### DIFF
--- a/roles/ansible/facts/tasks/main.yml
+++ b/roles/ansible/facts/tasks/main.yml
@@ -6,6 +6,6 @@
 
 ## Fetch facts
 - name: Facts | Generate facts
-  action: template src=hostvars.j2 dest=/tmp/facts.json
+  template: src=hostvars.j2 dest=/tmp/facts.json
 - name: Facts | Fetch facts
   fetch: src=/tmp/facts.json dest=fetched/{{ ansible_ssh_host }}/facts.json flat=yes fail_on_missing=yes

--- a/roles/database/beanstalkd/tasks/location.yml
+++ b/roles/database/beanstalkd/tasks/location.yml
@@ -6,10 +6,10 @@
 
 ## Setup custom location
 - name: Beanstalkd | Setup directory
-  action: file state=directory dest={{ beanstalkd_path }} mode=700 owner={{ beanstalkd_user }} group={{ beanstalkd_group }}
+  file: state=directory dest={{ beanstalkd_path }} mode=700 owner={{ beanstalkd_user }} group={{ beanstalkd_group }}
 - name: Beanstalkd | Move databases
   shell: service beanstalkd stop; cp -rf /var/lib/beanstalkd/* {{ beanstalkd_path }}; touch {{ beanstalkd_path }}/.ansible; chown -R {{ beanstalkd_user }}:{{ beanstalkd_group }} {{ beanstalkd_path }}; rm -rf /var/lib/beanstalkd
     creates={{ beanstalkd_path }}/.ansible
 - name: Beanstalkd | Link databases
-  action: file state=link src={{ beanstalkd_path }} path=/var/lib/beanstalkd force=yes
+  file: state=link src={{ beanstalkd_path }} path=/var/lib/beanstalkd force=yes
   notify: restart beanstalkd

--- a/roles/database/mongodb/tasks/install-arm.yml
+++ b/roles/database/mongodb/tasks/install-arm.yml
@@ -4,7 +4,7 @@
 # Part: MongoDB | ARM
 
 - name: MongoDB | ARM | Fetch package
-  action: get_url url=https://s3-eu-west-1.amazonaws.com/col-public-eu/mongodb-linux-armv7l-2.4.1.tgz dest=/opt
+  get_url: url=https://s3-eu-west-1.amazonaws.com/col-public-eu/mongodb-linux-armv7l-2.4.1.tgz dest=/opt
     sha256sum=c93fa070fa1df529428bb0685533db7bb649f1065025d8236c1d83ea9bd64d69
   register: result
 - name: MongoDB | ARM | Extract package

--- a/roles/database/mongodb/tasks/location.yml
+++ b/roles/database/mongodb/tasks/location.yml
@@ -6,10 +6,10 @@
 
 ## Setup custom location
 - name: MongoDB | Setup directory
-  action: file state=directory dest={{ mongodb_path }} mode=700 owner={{ mongodb_user }} group={{ mongodb_group }}
+  file: state=directory dest={{ mongodb_path }} mode=700 owner={{ mongodb_user }} group={{ mongodb_group }}
 - name: MongoDB | Move databases
   shell: service mongodb stop; cp -rf /var/lib/mongodb/* {{ mongodb_path }}; touch {{ mongodb_path }}/.ansible; chown -R {{ mongodb_user }}:{{ mongodb_group }} {{ mongodb_path }}; rm -rf /var/lib/mongodb
     creates={{ mongodb_path }}/.ansible
 - name: MongoDB | Link databases
-  action: file state=link src={{ mongodb_path }} path=/var/lib/mongodb force=yes
+  file: state=link src={{ mongodb_path }} path=/var/lib/mongodb force=yes
   notify: restart mongod

--- a/roles/database/mysql/tasks/location.yml
+++ b/roles/database/mysql/tasks/location.yml
@@ -6,12 +6,12 @@
 
 ## Setup custom location
 - name: MySQL | Setup directory
-  action: file state=directory dest={{ mysql_path }} mode=700 owner={{ mysql_user }} group={{ mysql_group }}
+  file: state=directory dest={{ mysql_path }} mode=700 owner={{ mysql_user }} group={{ mysql_group }}
 - name: MySQL | Move databases
   shell: service mysql stop; cp -rf /var/lib/mysql/* {{ mysql_path }}; touch {{ mysql_path }}/.ansible; chown -R {{ mysql_user }}:{{ mysql_group }} {{ mysql_path }}; rm -rf /var/lib/mysql
     creates={{ mysql_path }}/.ansible
 - name: MySQL | Link databases
-  action: file state=link src={{ mysql_path }} path=/var/lib/mysql force=yes
+  file: state=link src={{ mysql_path }} path=/var/lib/mysql force=yes
   notify: restart mysql
 
 ## Update apparmor profile

--- a/roles/database/redis/tasks/install-arm.yml
+++ b/roles/database/redis/tasks/install-arm.yml
@@ -6,7 +6,7 @@
 - name: Redis | Install package
   apt: name=build-essential state=latest
 - name: Redis | ARM | Fetch package
-  action: get_url url=http://download.redis.io/releases/redis-2.8.6.tar.gz dest=/opt
+  get_url: url=http://download.redis.io/releases/redis-2.8.6.tar.gz dest=/opt
     sha256sum=efd0c9cb8d2696db44d8cb8309fed96607f68b93bb126615e64bff364e716658
   register: result
 - name: Redis | ARM | Extract package

--- a/roles/database/redis/tasks/location.yml
+++ b/roles/database/redis/tasks/location.yml
@@ -5,10 +5,10 @@
 
 ## Setup custom location
 - name: Redis | Setup directory
-  action: file state=directory dest={{ redis_path }} mode=700 owner={{ redis_user }} group={{ redis_group }}
+  file: state=directory dest={{ redis_path }} mode=700 owner={{ redis_user }} group={{ redis_group }}
 - name: Redis | Move databases
   shell: service redis-server stop; cp -rf /var/lib/redis/* {{ redis_path }}; touch {{ redis_path }}/.ansible; chown -R {{ redis_user }}:{{ redis_group }} {{ redis_path }}; rm -rf /var/lib/redis
     creates={{ redis_path }}/.ansible
 - name: Redis | Link databases
-  action: file state=link src={{ redis_path }} path=/var/lib/redis force=yes
+  file: state=link src={{ redis_path }} path=/var/lib/redis force=yes
   notify: restart redis

--- a/roles/networking/openvpn/tasks/configure-server.yml
+++ b/roles/networking/openvpn/tasks/configure-server.yml
@@ -10,7 +10,7 @@
 
 ## Server setup
 # - name: OpenVPN | EasyRSA | Fetch package
-#   action: get_url url=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.0-rc1/EasyRSA-3.0.0-rc1.tgz dest=/opt/easyrsa-v3.0.0-rc1.tgz
+#   get_url: url=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.0-rc1/EasyRSA-3.0.0-rc1.tgz dest=/opt/easyrsa-v3.0.0-rc1.tgz
 #     sha256sum=3ee5f197120f25de772ae352616593120efca3d18c0afcaec5bd236c639bd952
 #   register: result
 # - name: OpenVPN | EasyRSA | Extract package

--- a/roles/networking/openvpn/tasks/install-arm.yml
+++ b/roles/networking/openvpn/tasks/install-arm.yml
@@ -10,7 +10,7 @@
     - libpam0g-dev
     - libssl-dev
 - name: OpenVPN | ARM | Fetch package
-  action: get_url url=http://swupdate.openvpn.org/community/releases/openvpn-{{ openvpn_arm_version }}.tar.gz dest=/opt
+  get_url: url=http://swupdate.openvpn.org/community/releases/openvpn-{{ openvpn_arm_version }}.tar.gz dest=/opt
     sha256sum={{ openvpn_arm_shasum }}
   register: result
 - name: OpenVPN | ARM | Extract package

--- a/roles/web/apache2/tasks/location.yml
+++ b/roles/web/apache2/tasks/location.yml
@@ -6,10 +6,10 @@
 
 ## Setup custom location
 - name: Apache2 | Setup directory
-  action: file state=directory dest={{ apache2_path }} mode=700 owner={{ apache2_user }} group={{ apache2_group }}
+  file: state=directory dest={{ apache2_path }} mode=700 owner={{ apache2_user }} group={{ apache2_group }}
 - name: Apache2 | Move directory
   shell: service apache2 stop; cp -rf /var/www/* {{ apache2_path }}; touch {{ apache2_path }}/.ansible; chown -R {{ apache2_user }}:{{ apache2_group }} {{ apache2_path }}; rm -rf /var/www
     creates={{ apache2_path }}/.ansible
 - name: Apache2 | Link directories
-  action: file state=link src={{ apache2_path }} path=/var/www force=yes
+  file: state=link src={{ apache2_path }} path=/var/www force=yes
   notify: restart apache2

--- a/roles/web/nginx/tasks/location.yml
+++ b/roles/web/nginx/tasks/location.yml
@@ -6,10 +6,10 @@
 
 ## Setup custom location
 - name: Nginx | Setup directory
-  action: file state=directory dest={{ nginx_path }} mode=700 owner={{ nginx_user }} group={{ nginx_group }}
+  file: state=directory dest={{ nginx_path }} mode=700 owner={{ nginx_user }} group={{ nginx_group }}
 - name: Nginx | Move directory
   shell: service nginx stop; cp -rf /var/www/* {{ nginx_path }}; touch {{ nginx_path }}/.ansible; chown -R {{ nginx_user }}:{{ nginx_group }} {{ nginx_path }}; rm -rf /var/www
     creates={{ nginx_path }}/.ansible
 - name: Nginx | Link directories
-  action: file state=link src={{ nginx_path }} path=/var/www force=yes
+  file: state=link src={{ nginx_path }} path=/var/www force=yes
   notify: restart nginx

--- a/roles/web/nodejs/tasks/install-armv7l.yml
+++ b/roles/web/nodejs/tasks/install-armv7l.yml
@@ -4,7 +4,7 @@
 # Part: NodeJS | Cubieboard
 
 - name: NodeJS | armv7l | Fetch package
-  action: get_url url=http://s3.armhf.com/debian/precise/node-v0.10.21-precise-armhf.tar.xz dest=/opt
+  get_url: url=http://s3.armhf.com/debian/precise/node-v0.10.21-precise-armhf.tar.xz dest=/opt
     sha256sum=284710e6720aa808f788b59b6ce253739aa6a59f4a5f5e94dd84c5bf306b51d7
   register: result
 - name: NodeJS | armv7l | Install package

--- a/roles/web/nodejs/tasks/install-raspberry.yml
+++ b/roles/web/nodejs/tasks/install-raspberry.yml
@@ -4,7 +4,7 @@
 # Part: NodeJS | Raspberry
 
 - name: NodeJS | Raspberry | Fetch package
-  action: get_url url=http://nodejs.org/dist/v0.10.21/node-v0.10.21-linux-arm-pi.tar.gz dest=/opt
+  get_url: url=http://nodejs.org/dist/v0.10.21/node-v0.10.21-linux-arm-pi.tar.gz dest=/opt
     sha256sum=5a5c3b4a9c98fa850cc8c5f6fa06213b856f217e368452fc6ac5f5868044ff39
   register: result
 - name: NodeJS | Raspberry | Install package


### PR DESCRIPTION
The shorthand syntax is recommended by Ansible documentation and is already used for most of the other tasks.
